### PR TITLE
글 좋아요 추가, 좋아요 취소 기능

### DIFF
--- a/src/main/java/com/wgc/wgcapi/Member/Entity/Member.java
+++ b/src/main/java/com/wgc/wgcapi/Member/Entity/Member.java
@@ -6,6 +6,7 @@ by jeon-wangi
 
 import com.wgc.wgcapi.Member.DTO.MemberDto;
 import com.wgc.wgcapi.Post.Entity.Post;
+import com.wgc.wgcapi.Post.Entity.PostLike;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,6 +47,11 @@ public class Member {
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "writer")
     private Set<Post> posts = new HashSet<>();
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "member")
+    private Set<PostLike> postLikes = new HashSet<>();
+
+
 
     public Member(String name, String mail, String password) {
         this.name = name;

--- a/src/main/java/com/wgc/wgcapi/Post/Controller/PostController.java
+++ b/src/main/java/com/wgc/wgcapi/Post/Controller/PostController.java
@@ -54,5 +54,17 @@ public class PostController {
     public ResponseDto getPostList(@PathVariable(name = "categoryId") Long categoryId) {
         return this.postService.getPostList(categoryId);
     }
+    @PostMapping("/{id}/like")
+    @RequireToken
+    public ResponseDto likePost(@PathVariable(name = "id") Long id, HttpServletRequest request) {
+        return this.postService.likePost(request, id);
+    }
+
+    @PostMapping("/{id}/dislike")
+    @RequireToken
+    public ResponseDto dislikePost(@PathVariable(name = "id") Long id, HttpServletRequest request) {
+        return this.postService.dislikePost(request, id);
+    }
+
 
 }

--- a/src/main/java/com/wgc/wgcapi/Post/Entity/Post.java
+++ b/src/main/java/com/wgc/wgcapi/Post/Entity/Post.java
@@ -17,6 +17,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "post", catalog = "wgc")
@@ -38,6 +40,9 @@ public class Post {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "post")
+    private Set<PostLike> postLikes = new HashSet<>();
 
     @Column(name = "title")
     private String title;
@@ -78,4 +83,11 @@ public class Post {
     public void delete() {
         this.isDelete = 'Y';
     }
+
+    public void incrementLikeCount() { this.like++;}
+
+
+    public void decrementLikeCount() { this.like--;}
+
+
 }

--- a/src/main/java/com/wgc/wgcapi/Post/Entity/PostLike.java
+++ b/src/main/java/com/wgc/wgcapi/Post/Entity/PostLike.java
@@ -1,0 +1,46 @@
+package com.wgc.wgcapi.Post.Entity;
+
+import com.wgc.wgcapi.Member.Entity.Member;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+import java.time.LocalDateTime;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name = "postlike", catalog = "wgc")
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class PostLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Column(updatable = false)
+    private LocalDateTime likedAt;
+
+    @PrePersist
+    private void onPrePersist() {
+        this.likedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public PostLike(Member member, Post post) {
+        this.member = member;
+        this.post = post;
+    }
+}

--- a/src/main/java/com/wgc/wgcapi/Post/Repository/PostLikeRepository.java
+++ b/src/main/java/com/wgc/wgcapi/Post/Repository/PostLikeRepository.java
@@ -1,0 +1,15 @@
+package com.wgc.wgcapi.Post.Repository;
+
+import com.wgc.wgcapi.Member.Entity.Member;
+import com.wgc.wgcapi.Post.Entity.Post;
+import com.wgc.wgcapi.Post.Entity.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface  PostLikeRepository extends JpaRepository<PostLike, Long> {
+
+    boolean existsByMemberAndPost(Member member, Post post);
+
+    Optional<PostLike> findByMemberAndPost(Member member, Post post);
+}

--- a/src/main/java/com/wgc/wgcapi/Post/Repository/PostRepository.java
+++ b/src/main/java/com/wgc/wgcapi/Post/Repository/PostRepository.java
@@ -4,11 +4,14 @@ Created on 2023/04/13 12:10 AM In Intelli J IDEA
 by jeon-wangi
 */
 
+import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wgc.wgcapi.Member.DTO.MemberDto;
+import com.wgc.wgcapi.Member.Entity.Member;
 import com.wgc.wgcapi.Member.Entity.QMember;
 import com.wgc.wgcapi.Post.DTO.ResponsePostDto;
+import com.wgc.wgcapi.Post.Entity.Post;
 import com.wgc.wgcapi.Post.Entity.QPost;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -47,4 +50,6 @@ public class PostRepository {
                 .limit(limit)
                 .fetch();
     }
+
+
 }

--- a/src/main/java/com/wgc/wgcapi/Post/Service/PostLikeWriteService.java
+++ b/src/main/java/com/wgc/wgcapi/Post/Service/PostLikeWriteService.java
@@ -1,0 +1,48 @@
+package com.wgc.wgcapi.Post.Service;
+
+import com.wgc.wgcapi.Common.DTO.ResponseDto;
+import com.wgc.wgcapi.Member.Entity.Member;
+import com.wgc.wgcapi.Post.Entity.Post;
+import com.wgc.wgcapi.Post.Entity.PostLike;
+import com.wgc.wgcapi.Post.Repository.PostLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostLikeWriteService {
+    private final PostLikeRepository postLikeRepository;
+
+    public ResponseDto like(Member member, Post post) {
+        if (checkLiked(member, post)) {
+            return new ResponseDto(HttpStatus.BAD_REQUEST, "이미 좋아요를 누른 게시글입니다.");
+        }
+
+        PostLike newPostLike = PostLike.builder().member(member).post(post).build();
+        post.incrementLikeCount();
+        postLikeRepository.save(newPostLike);
+        return new ResponseDto(HttpStatus.OK, "좋아요를 눌렀습니다.");
+    }
+
+    public ResponseDto dislike(Member member, Post post) {
+        Optional<PostLike> getPostLike = postLikeRepository.findByMemberAndPost(member, post);
+
+        if (getPostLike.isEmpty()) {
+            return new ResponseDto(HttpStatus.BAD_REQUEST, "좋아요를 누르지 않은 게시글입니다.");
+        }
+
+        post.decrementLikeCount();
+        postLikeRepository.delete(getPostLike.get());
+        return new ResponseDto(HttpStatus.OK, "좋아요가 취소되었습니다.");
+    }
+
+    private boolean checkLiked(Member member, Post post) {
+        return postLikeRepository.existsByMemberAndPost(member, post);
+    }
+}
+

--- a/src/main/java/com/wgc/wgcapi/Post/Service/PostService.java
+++ b/src/main/java/com/wgc/wgcapi/Post/Service/PostService.java
@@ -37,6 +37,7 @@ public class PostService {
     private final CategoryService categoryService;
     private final PostDataJpaRepository postJpaRepository;
     private final CategoryDataRepository categoryDataRepository;
+    private final PostLikeWriteService postLikeWriteService;
 
     public ResponseDto writePost(HttpServletRequest request, WritePostDto dto) {
         Member member = this.getMemberInfo(request);
@@ -119,4 +120,30 @@ public class PostService {
 
         return new ResponseDto(result);
     }
+
+    public ResponseDto likePost(HttpServletRequest request, Long id) {
+
+        Member getMember = this.getMemberInfo(request);
+        Post getPost = this.findPostById(id);
+
+        if(Objects.isNull(getPost))
+            return new ResponseDto(HttpStatus.NOT_FOUND, "post is not found !");
+
+        return postLikeWriteService.like(getMember, getPost);
+
+
+    }
+
+    public ResponseDto dislikePost(HttpServletRequest request, Long id) {
+        Member getMember = this.getMemberInfo(request);
+        Post getPost = this.findPostById(id);
+
+        if(Objects.isNull(getPost))
+            return new ResponseDto(HttpStatus.NOT_FOUND, "post is not found !");
+
+       return postLikeWriteService.dislike(getMember, getPost);
+
+    }
+
+
 }


### PR DESCRIPTION
작업 주제
-------------

- 글 좋아요 추가, 좋아요 취소 기능 구현

작업 내용
-------------

- 해당되는 게시물의 좋아요 추가, 삭제하는 기능입니다

- postLike라는 테이블을 따로 두고 좋아요 시 member와 post를 모두 저장하고 사용자 1명당 1번의 좋아요를 할 수 있게 구현했습니다

- 이후 post에서 좋아요 수를 증가하는 로직이 있습니다

- Transaction을 PostLike테이블과 Post테이블에 대해서 분리를 해놓은 상태입니다 그래서 동시성으로 인해 좋아요 수가 증가되지 않더라도 해당 사용자의 좋아요 수는 반영될 수 있도록 하고 있습니다

- (#3) 좋아요 기능 이슈에 적어놓은 해결 방법에 대해서 고민하는 이유는 매번 PostLike테이블에서 count 쿼리를 날리게 되는 상황이 부화가 많이 발생할거라 생각했기 때문입니다

- 또한 비관적 락을 쓸 경우 개발자 입장에서 편하지만 사용자 입장에서 좋아요가 실패하는 상황이 나올거라 생각합니다

화면 스크린샷
-------------
```
@Service
@RequiredArgsConstructor
@Transactional
public class PostWriteService {

    private final PostRepository postRepository;
    
// 중략
     public ResponseDto like(Member member, Post post) {
// 중략
        post.incrementLikeCount();
// 중략
    }

  public ResponseDto dislike(Member member, Post post) {
//중략
        post.decrementLikeCount();
//중략
    }
//중략
}
```

- PostWriteService에는 현재는 Post를 넘겨서 증가 시켜주는 로직이 포함되어 있습니다. 고민인 부분은 낙관적락을 고려하는 상황입니다 낙관적락은 조회 -> 조회 된 post에서 version이 같아야 update된다 이렇게 파악하고 있는데 각각 트랜잭션이 다 분리된 상황이여서
- post 조회 -> postLike table insert -> post like Update 이 과정보다
- post 조회 -> postLike table insert -> post다시 조회 ->post like Update  
- 이 과정이 좋아요 수 반영이 더 잘될 거 같다는 생각이듭니다